### PR TITLE
FIX: Error opening zip file: newrelic.jar when running outside bin

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/newrelic/AddAgentTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/newrelic/AddAgentTask.groovy
@@ -9,7 +9,7 @@ class AddAgentTask extends DefaultTask {
     @TaskAction
     void addNewrelic() {
         project.applicationDefaultJvmArgs += [
-                "-javaagent:../lib/${NewrelicPlugin.NEWRELIC_AGENT_NAME}-${project.extensions.newrelic.version}.jar"
+                "-javaagent:$( cd "$( echo "${BASH_SOURCE[0]%/*}" )" && pwd )/../lib/${NewrelicPlugin.NEWRELIC_AGENT_NAME}-${project.extensions.newrelic.version}.jar"
         ]
     }
 


### PR DESCRIPTION
The path to the agent jar file must be fully qualified in the -javaagent JVM switch.
see https://docs.newrelic.com/docs/agents/java-agent/troubleshooting/error-starting-app-server-java

Hacky PR, but can be used as quick fix, if someone need it :/
